### PR TITLE
Fix change display and approval bugs for ID-tracked arrays

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -279,7 +279,7 @@ class NavalUnitAssignmentDict(Form):
 class ModifierForm(Form):
     """Form for handling nation/character modifiers as a dictionary"""
 
-    _id = HiddenField('_id')
+    item_id = HiddenField('_id')
     field = StringField("Field", validators=[DataRequired()])
     value = FloatField("Value", default=1)
     duration = IntegerField("Duration", validators=[NumberRange()], default=-1)
@@ -287,7 +287,7 @@ class ModifierForm(Form):
 
     class Meta:
         csrf = False
-    
+
     def load_form_from_item(self, item, schema):
         """Loads form data from a database item"""
 
@@ -297,18 +297,18 @@ class ModifierForm(Form):
         for field_name, field in self._fields.items():
                 if isinstance(field, SelectField) and field.data:
                     field.data = str(field.data)
-                    
+
                 # Handle nested data structures
                 if field_name in item:
                     field_value = item[field_name]
-                    
+
                     if isinstance(field_value, ObjectId):
                         field.data = str(field_value)
                     elif isinstance(field, FieldList):
                         # Clear existing entries
                         while len(field.entries) > 0:
                             field.pop_entry()
-                            
+
                         # Add new entries from the data
                         for value in field_value:
                             if isinstance(value, dict):
@@ -325,10 +325,15 @@ class ModifierForm(Form):
                     else:
                         field.data = field_value
 
+        # Map _id from DB doc to item_id field (WTForms cannot register field
+        # names that start with '_', so we expose it as item_id instead).
+        if '_id' in item:
+            self._fields['item_id'].data = str(item['_id'])
+
 class ProgressQuestForm(Form):
     """Form for handling progress quests as a dictionary"""
 
-    _id = HiddenField('_id')
+    item_id = HiddenField('_id')
     quest_name = StringField("Quest Name", validators=[DataRequired()])
     bonus_progress_per_tick = IntegerField("Bonus Progress Per Tick", validators=[NumberRange()], default=0)
     current_progress = IntegerField("Current Progress", validators=[NumberRange()], default=0)
@@ -338,7 +343,7 @@ class ProgressQuestForm(Form):
 
     class Meta:
         csrf = False
-    
+
     def load_form_from_item(self, item, schema):
         """Loads form data from a database item"""
 
@@ -348,18 +353,18 @@ class ProgressQuestForm(Form):
         for field_name, field in self._fields.items():
                 if isinstance(field, SelectField) and field.data:
                     field.data = str(field.data)
-                    
+
                 # Handle nested data structures
                 if field_name in item:
                     field_value = item[field_name]
-                    
+
                     if isinstance(field_value, ObjectId):
                         field.data = str(field_value)
                     elif isinstance(field, FieldList):
                         # Clear existing entries
                         while len(field.entries) > 0:
                             field.pop_entry()
-                            
+
                         # Add new entries from the data
                         for value in field_value:
                             if isinstance(value, dict):
@@ -374,12 +379,18 @@ class ProgressQuestForm(Form):
                     elif isinstance(field, FormField):
                         field.load_form_from_item(field_value, schema)
                     else:
-                        field.data = field_value        
+                        field.data = field_value
+
+        # Map _id from DB doc to item_id field (WTForms cannot register field
+        # names that start with '_', so we expose it as item_id instead).
+        if '_id' in item:
+            self._fields['item_id'].data = str(item['_id'])
+
 
 class DistrictDict(Form):
     """Form for handling each district as a dictionary"""
 
-    _id = HiddenField('_id')
+    item_id = HiddenField('_id')
     type = SelectField("District Type", choices=[("", "None")], default="")
     node = SelectField("Node Type", choices=[("", "None")], default="")
 
@@ -404,18 +415,18 @@ class DistrictDict(Form):
         for field_name, field in self._fields.items():
                 if isinstance(field, SelectField) and field.data:
                     field.data = str(field.data)
-                    
+
                 # Handle nested data structures
                 if field_name in item:
                     field_value = item[field_name]
-                    
+
                     if isinstance(field_value, ObjectId):
                         field.data = str(field_value)
                     elif isinstance(field, FieldList):
                         # Clear existing entries
                         while len(field.entries) > 0:
                             field.pop_entry()
-                            
+
                         # Add new entries from the data
                         for value in field_value:
                             if isinstance(value, dict):
@@ -432,10 +443,15 @@ class DistrictDict(Form):
                     else:
                         field.data = field_value
 
+        # Map _id from DB doc to item_id field (WTForms cannot register field
+        # names that start with '_', so we expose it as item_id instead).
+        if '_id' in item:
+            self._fields['item_id'].data = str(item['_id'])
+
 class CityDict(Form):
     """Form for handling each City as a dictionary"""
 
-    _id = HiddenField('_id')
+    item_id = HiddenField('_id')
     name = StringField("City Name")
     type = SelectField("City Type")
     node = SelectField("Node Type")
@@ -465,18 +481,18 @@ class CityDict(Form):
         for field_name, field in self._fields.items():
                 if isinstance(field, SelectField) and field.data:
                     field.data = str(field.data)
-                    
+
                 # Handle nested data structures
                 if field_name in item:
                     field_value = item[field_name]
-                    
+
                     if isinstance(field_value, ObjectId):
                         field.data = str(field_value)
                     elif isinstance(field, FieldList):
                         # Clear existing entries
                         while len(field.entries) > 0:
                             field.pop_entry()
-                            
+
                         # Add new entries from the data
                         for value in field_value:
                             if isinstance(value, dict):
@@ -493,12 +509,17 @@ class CityDict(Form):
                     else:
                         field.data = field_value
 
+        # Map _id from DB doc to item_id field (WTForms cannot register field
+        # names that start with '_', so we expose it as item_id instead).
+        if '_id' in item:
+            self._fields['item_id'].data = str(item['_id'])
+
 class ExternalModifierForm(Form):
     """Generic form for handling non-nation modifiers based on schema"""
     class Meta:
         csrf = False
 
-    _id = HiddenField('_id')
+    item_id = HiddenField('_id')
     type = SelectField("Type", choices=[("nation", "nation"), ("character", "character")])
     modifier = StringField("Modifier", validators=[])
     value = FloatField("Value")
@@ -843,6 +864,9 @@ class BaseSchemaForm(FlaskForm):
                         districts = districts[:max_districts]
 
                     for district in districts:
+                        if isinstance(district, dict) and '_id' in district:
+                            district = dict(district)
+                            district['item_id'] = str(district['_id'])
                         field.append_entry(district)
                 
                 elif field_name == "cities":
@@ -858,6 +882,9 @@ class BaseSchemaForm(FlaskForm):
                         cities = cities[:max_cities]
                     
                     for cities in cities:
+                        if isinstance(cities, dict) and '_id' in cities:
+                            cities = dict(cities)
+                            cities['item_id'] = str(cities['_id'])
                         field.append_entry(cities)
                 
                 elif field_name == "positive_titles":
@@ -896,8 +923,13 @@ class BaseSchemaForm(FlaskForm):
                     # Add new entries from the data
                     for value in field_value:
                         if isinstance(value, dict):
-                            # For object arrays
-                            field.append_entry(value)
+                            # For object arrays — inject item_id from _id so that
+                            # sub-forms (which use item_id as WTForms can't register
+                            # underscore-prefixed field names) are populated correctly.
+                            entry_value = dict(value)
+                            if '_id' in entry_value:
+                                entry_value['item_id'] = str(entry_value['_id'])
+                            field.append_entry(entry_value)
                         elif isinstance(value, ObjectId):
                             # For linked object arrays
                             field.append_entry(str(value))

--- a/helpers/change_helpers.py
+++ b/helpers/change_helpers.py
@@ -6,11 +6,101 @@ from calculations.field_calculations import calculate_all_fields
 from copy import deepcopy
 from bson import ObjectId
 
+_NATURAL_KEY_FIELDS = ['name', 'quest_name', 'source', 'field', 'key']
+
+
+def _get_natural_key(item):
+    """Return the first non-empty value from a priority list of identifying fields."""
+    for field in _NATURAL_KEY_FIELDS:
+        val = item.get(field)
+        if val:
+            return str(val)
+    return None
+
+
+def _reconcile_item_ids(before_data, after_data):
+    """Propagate stable _id values from before_data to matching after_data items.
+
+    When after_data items lack a valid _id (e.g. because a form did not include
+    the hidden _id input), this matches them to before_data items by natural key
+    (quest_name, name, etc.) and copies the original _id.  This preserves
+    identity across request/display so that the diff correctly shows only the
+    fields that actually changed rather than treating every item as removed and
+    re-added.
+
+    Call this BEFORE _ensure_item_ids so that truly new items (no match in
+    before) still get a fresh id from _ensure_item_ids.
+    """
+    if isinstance(before_data, dict) and isinstance(after_data, dict):
+        for key in after_data:
+            if key in before_data:
+                _reconcile_item_ids(before_data[key], after_data[key])
+    elif isinstance(before_data, list) and isinstance(after_data, list):
+        if not _all_have_ids(before_data):
+            return
+
+        before_ids = {item['_id'] for item in before_data if isinstance(item, dict) and '_id' in item}
+
+        # Index before items by natural key for O(1) lookup
+        before_by_key = {}
+        for item in before_data:
+            if isinstance(item, dict):
+                nk = _get_natural_key(item)
+                if nk and nk not in before_by_key:
+                    before_by_key[nk] = item
+
+        # Track which before IDs have already been claimed by an after item
+        claimed = set()
+        for after_item in after_data:
+            if isinstance(after_item, dict) and after_item.get('_id') in before_ids:
+                claimed.add(after_item['_id'])
+
+        for after_item in after_data:
+            if not isinstance(after_item, dict):
+                continue
+            # Already has a valid before ID — nothing to do
+            if after_item.get('_id') in before_ids:
+                continue
+            nk = _get_natural_key(after_item)
+            if nk and nk in before_by_key:
+                bid = before_by_key[nk].get('_id')
+                if bid and bid not in claimed:
+                    after_item['_id'] = bid
+                    claimed.add(bid)
+
+
+def _normalize_item_ids(data):
+    """Recursively rename ``item_id`` → ``_id`` in submitted form data.
+
+    WTForms cannot register field names that start with ``_``, so the stable
+    sub-document identity field is exposed to forms as ``item_id``.  This
+    function renames it back to ``_id`` before the data enters the change
+    pipeline so that _reconcile_item_ids can match submitted items against
+    the stored before_data by their original IDs.
+
+    Only call this on data that came from a form submission (i.e. in
+    ``request_change``), not on data generated internally (``system_request_change``).
+    """
+    if isinstance(data, dict):
+        for value in data.values():
+            _normalize_item_ids(value)
+    elif isinstance(data, list):
+        for item in data:
+            if isinstance(item, dict):
+                if 'item_id' in item:
+                    raw_id = item.pop('item_id')
+                    if raw_id:  # only promote non-empty values
+                        item['_id'] = raw_id
+                _normalize_item_ids(item)
+
+
 def _ensure_item_ids(data):
     """Recursively assign a _id to any dict item inside a list that lacks one.
 
     Call this on ``after_data`` before computing diffs so that newly added
     sub-document items receive a stable identity at request time.
+    Also replaces empty-string or None _id values (e.g. from unrendered form
+    hidden fields) with fresh ids.
     """
     if isinstance(data, dict):
         for value in data.values():
@@ -18,7 +108,7 @@ def _ensure_item_ids(data):
     elif isinstance(data, list):
         for item in data:
             if isinstance(item, dict):
-                if '_id' not in item:
+                if not item.get('_id'):
                     item['_id'] = uuid.uuid4().hex[:8]
                 _ensure_item_ids(item)
 
@@ -66,8 +156,12 @@ def request_change(data_type, item_id, change_type, before_data, after_data, rea
     before_data.pop("_id", None)
     after_data.pop("_id", None)
 
-    # Stamp IDs on any new sub-document list items in after_data so reorders
-    # can be detected later via ID-based matching.
+    # Rename item_id → _id in form-submitted data (WTForms cannot register
+    # field names starting with '_', so the hidden field is named item_id).
+    _normalize_item_ids(after_data)
+    # Propagate stable IDs from before to after where items match by natural key,
+    # then stamp fresh IDs on any remaining items that still lack one.
+    _reconcile_item_ids(before_data, after_data)
     _ensure_item_ids(after_data)
 
     before_data, after_data = keep_only_differences(before_data, after_data, change_type)
@@ -101,6 +195,7 @@ def system_request_change(data_type, item_id, change_type, before_data, after_da
     before_data.pop("_id", None)
     after_data.pop("_id", None)
 
+    _reconcile_item_ids(before_data, after_data)
     _ensure_item_ids(after_data)
 
     before_data, after_data = keep_only_differences(before_data, after_data, change_type)
@@ -344,8 +439,14 @@ def keep_only_differences(before_data, after_data, change_type):
 def keep_only_differences_dict(before_data, after_data):
     new_before = {}
     new_after = {}
-    if len(after_data) == 0 and not deep_compare(before_data, after_data):  # If after_data is empty and before_data is not, then we want to include it in the changes to clear the data 
-        return before_data, after_data
+    # Note: an empty after_data ({}) is treated as "nothing was submitted
+    # for this sub-document" rather than "the user intentionally cleared it".
+    # This prevents FormField sub-forms that have no registered fields
+    # (e.g. NavalUnitAssignmentDict when naval_unit_details is empty) from
+    # generating spurious "all values → None" diffs.  The normal key loop
+    # below handles all real changes correctly: if after_data has keys, they
+    # are compared against before_data; if after_data is empty, no keys are
+    # iterated and the function returns ({}, {}) — meaning no change.
 
     for key in after_data.keys():
         current_before = before_data.get(key)
@@ -365,12 +466,38 @@ def keep_only_differences_dict(before_data, after_data):
     return new_before, new_after
 
 def keep_only_differences_list(before_data, after_data):
-    # When all dict items in both lists carry a stable _id, store the full
-    # lists verbatim.  deep_compare will detect whether anything changed
-    # (including pure reorders), and deep_merge / check_no_other_changes will
-    # use ID-based matching at approval time.
+    # When all dict items in both lists carry a stable _id, preserve order
+    # information and use ID-based matching at approval / display time.
+    # Before returning, we restrict each before-item's keys to the set of
+    # keys present in its matching after-item.  This prevents calculated
+    # fields (e.g. total_progress_per_tick) that exist in the DB's before
+    # snapshot but are never submitted by forms from appearing as spurious
+    # "X → None" modifications in the change display.  Items that were
+    # removed (only in before) keep all their keys so the display can show
+    # what was there.
     if _all_have_ids(before_data) and _all_have_ids(after_data):
-        return list(before_data), list(after_data)
+        after_by_id = {
+            item['_id']: item
+            for item in after_data
+            if isinstance(item, dict) and '_id' in item
+        }
+        filtered_before = []
+        for item in before_data:
+            if not isinstance(item, dict) or '_id' not in item:
+                filtered_before.append(item)
+            elif item['_id'] in after_by_id:
+                # Item exists in both snapshots: only track keys the form
+                # submitted so that server-computed fields are not shown as
+                # going from a real value to None.
+                after_item = after_by_id[item['_id']]
+                filtered_before.append(
+                    {k: v for k, v in item.items() if k in after_item}
+                )
+            else:
+                # Item was removed — keep all keys so the display can show
+                # everything that was there before removal.
+                filtered_before.append(dict(item))
+        return filtered_before, list(after_data)
 
     # Positional fallback for legacy data without IDs.
     new_before = []
@@ -435,7 +562,14 @@ def check_no_other_changes(before_data, after_data, current_data):
                         return False  # Externally added item
                     b_item = b_map.get(item_id, {})
                     a_item = a_map.get(item_id, {})
-                    if not (deep_compare(c_item, b_item) or deep_compare(c_item, a_item)):
+                    # Project c_item onto only the keys tracked by b_item / a_item.
+                    # The live DB document may contain server-calculated fields (e.g.
+                    # total_progress_per_tick) that were stripped from the stored
+                    # before/after items by keep_only_differences_list.  Those extra
+                    # fields must not cause a false "target has changed" failure.
+                    c_proj_b = {k: c_item.get(k) for k in b_item}
+                    c_proj_a = {k: c_item.get(k) for k in a_item}
+                    if not (deep_compare(c_proj_b, b_item) or deep_compare(c_proj_a, a_item)):
                         return False  # Content changed externally
 
                 # Items that were in before AND after (i.e. being modified, not removed)

--- a/static/styles.css
+++ b/static/styles.css
@@ -772,6 +772,140 @@ h1, h2 {
     margin-left: 15px;
 }
 
+/* ── Change diff: array section containers ──────────────────── */
+.array-changes {
+    margin-top: 4px;
+}
+
+.array-section {
+    margin-bottom: 6px;
+}
+
+.array-section-header {
+    font-weight: bold;
+    font-size: 0.85em;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: 4px;
+}
+
+.array-items-added    .array-section-header { color: #4CAF50; }
+.array-items-removed  .array-section-header { color: #f44336; }
+.array-items-modified .array-section-header { color: #e0a800; }
+.array-items-reordered .array-section-header { color: #64b5f6; }
+
+/* Individual diff items */
+.array-item-added,
+.array-item-removed,
+.array-item-changed {
+    padding: 3px 6px;
+    margin-bottom: 3px;
+    border-left: 2px solid transparent;
+    font-size: 0.9em;
+}
+
+.array-item-added   { border-left-color: #4CAF50; }
+.array-item-removed { border-left-color: #f44336; }
+.array-item-changed { border-left-color: #e0a800; }
+
+.array-item-header {
+    font-weight: bold;
+    margin-bottom: 2px;
+}
+
+.array-item-body {
+    padding-left: 8px;
+}
+
+.dict-change-item {
+    margin-bottom: 2px;
+}
+
+.dict-key {
+    color: #888;
+    margin-right: 4px;
+}
+
+.dict-value {
+    color: #ccc;
+}
+
+.simple-change {
+    color: #ccc;
+}
+
+.no-changes {
+    color: #555;
+    font-style: italic;
+    font-size: 0.85em;
+}
+
+.field-added   { color: #4CAF50; }
+.field-removed { color: #f44336; }
+
+.nested-dict-change {
+    padding-left: 10px;
+    border-left: 1px solid #444;
+}
+
+/* ── Reorder table ──────────────────────────────────────────── */
+/*  Shows the before/after ordering side-by-side, one row per
+    position.  Rows where the item is the same in both columns
+    are muted; rows where items differ are highlighted in amber.  */
+.reorder-table {
+    border-collapse: collapse;
+    font-size: 0.85em;
+    margin-top: 6px;
+    width: 100%;
+}
+
+.reorder-table th {
+    text-align: left;
+    padding: 3px 8px;
+    background-color: #2a2d3a;
+    color: #aaa;
+    font-weight: normal;
+    border-bottom: 1px solid #444;
+}
+
+.reorder-pos-header {
+    width: 2em;
+    text-align: right;
+    padding-right: 4px !important;
+}
+
+.reorder-table td {
+    padding: 2px 8px;
+    border-bottom: 1px solid #222;
+}
+
+.reorder-pos-num {
+    color: #555;
+    text-align: right;
+    width: 2em;
+    font-size: 0.8em;
+    padding-right: 4px !important;
+}
+
+/* Unchanged rows: heavily muted so the eye skips them */
+.reorder-row-same td {
+    color: #555;
+}
+
+.reorder-row-same .reorder-pos-num {
+    color: #3a3a3a;
+}
+
+/* Changed rows: amber highlight so the eye finds them immediately */
+.reorder-row-moved td {
+    color: #e0a800;
+    font-weight: 500;
+}
+
+.reorder-row-moved .reorder-pos-num {
+    color: #b07d00;
+}
+
 .action-buttons {
     display: flex;
     gap: 5px;

--- a/templates/dataItemEdit.html
+++ b/templates/dataItemEdit.html
@@ -45,7 +45,7 @@
 									<tbody id="{{ field.name }}-tbody">
 										{% for modifier_field in field %}
 											<tr>
-												<td>{{ modifier_field.form.type(class="form-control") }}</td>
+												<td>{{ modifier_field.form.item_id() }}{{ modifier_field.form.type(class="form-control") }}</td>
 												<td>{{ modifier_field.form.modifier(class="form-control") }}</td>
 												<td>{{ modifier_field.form.value(class="form-control") }}</td>
 												<td>
@@ -71,7 +71,7 @@
 									<tbody id="{{ field.name }}-tbody">
 										{% for modifier_field in field %}
 											<tr>
-												<td>{{ modifier_field.form.field(class="form-control") }}</td>
+												<td>{{ modifier_field.form.item_id() }}{{ modifier_field.form.field(class="form-control") }}</td>
 												<td>{{ modifier_field.form.value(class="form-control") }}</td>
 												<td>{{ modifier_field.form.duration(class="form-control") }}</td>
 												<td>{{ modifier_field.form.source(class="form-control") }}</td>
@@ -100,7 +100,7 @@
 									<tbody id="{{ field.name }}-tbody" class="sortable-tbody">
 										{% for quest_field in field %}
 											<tr class="sortable-row">
-												<td>{{ quest_field.form.quest_name(class="form-control") }}</td>
+												<td>{{ quest_field.form.item_id() }}{{ quest_field.form.quest_name(class="form-control") }}</td>
 												<td>{{ quest_field.form.slot(class="form-control") }}</td>
 												<td>{{ quest_field.form.bonus_progress_per_tick(class="form-control") }}</td>
 												<td>{{ quest_field.form.current_progress(class="form-control") }}</td>

--- a/templates/macros/pagination.html
+++ b/templates/macros/pagination.html
@@ -45,6 +45,15 @@
     {% if ns.found %}{{ ns.found }}{% elif item._id is defined %}{{ item._id }}{% else %}item{% endif %}
 {% endmacro %}
 
+{# Same as _item_label but with whitespace stripped, safe for equality comparisons. #}
+{%- macro _label_for(item) -%}
+{%- set ns = namespace(found='') -%}
+{%- for k in ['name', 'quest_name', 'source', 'field', 'key', 'type', 'modifier'] -%}
+    {%- if ns.found == '' and item.get(k) -%}{%- set ns.found = item.get(k) | string -%}{%- endif -%}
+{%- endfor -%}
+{%- if ns.found -%}{{ ns.found }}{%- elif item._id is defined -%}{{ item._id }}{%- else -%}item{%- endif -%}
+{%- endmacro -%}
+
 {# Render all key:value pairs of a dict, skipping _id #}
 {% macro _item_fields(item) %}
     {% for k, v in item.items() %}
@@ -102,8 +111,25 @@
 {# Render a diff for an array whose dict items carry stable ``_id`` values.
    Classifies each item as ADDED, REMOVED, MODIFIED, or (if order changed)
    shows a REORDERED summary.  Items with identical content in both snapshots
-   at the same relative position are silently skipped. #}
+   at the same relative position are silently skipped.
+   Falls back to label-based matching when no _id values overlap (e.g. when
+   IDs were regenerated during form submission). #}
 {% macro _id_array_diff(before_value, after_value) %}
+    {# Check whether any _id values overlap between before and after. #}
+    {% set ns_chk = namespace(any_match=false) %}
+    {% for bi in before_value %}
+        {% if not ns_chk.any_match and bi is mapping and bi._id is defined %}
+            {% for ai in after_value %}
+                {% if not ns_chk.any_match and ai is mapping and ai._id is defined and ai._id == bi._id %}
+                    {% set ns_chk.any_match = true %}
+                {% endif %}
+            {% endfor %}
+        {% endif %}
+    {% endfor %}
+
+    {% if ns_chk.any_match %}
+    {# ===== Standard ID-based matching ===== #}
+
     {# --- ADDED (present in after, absent from before by _id) --- #}
     {% set ns = namespace(count=0) %}
     {% for after_item in after_value %}
@@ -183,23 +209,163 @@
     {% if before_common != after_common and before_common|length > 1 %}
         <div class="array-section array-items-reordered">
             <div class="array-section-header">Reordered:</div>
-            <div class="reorder-detail">
-                <div class="reorder-row">
-                    <span class="reorder-label">Before:</span>
-                    {% for item_id in before_common %}
-                        {% set items = before_value | selectattr('_id', 'equalto', item_id) | list %}
-                        {% if items %}<span class="reorder-item">{{ _item_label(items[0]) }}</span>{% if not loop.last %} <span class="reorder-arrow">→</span> {% endif %}{% endif %}
+            <table class="reorder-table">
+                <thead>
+                    <tr>
+                        <th class="reorder-pos-header">#</th>
+                        <th>Before</th>
+                        <th>After</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% set max_len = [before_common|length, after_common|length]|max %}
+                    {% for i in range(max_len) %}
+                        {% set b_id = before_common[i] if i < before_common|length else '' %}
+                        {% set a_id = after_common[i] if i < after_common|length else '' %}
+                        {% set row_moved = (b_id != a_id) %}
+                        <tr class="{{ 'reorder-row-moved' if row_moved else 'reorder-row-same' }}">
+                            <td class="reorder-pos-num">{{ i + 1 }}</td>
+                            <td class="reorder-cell">
+                                {%- if b_id -%}
+                                    {%- set b_items = before_value | selectattr('_id', 'equalto', b_id) | list -%}
+                                    {{ _item_label(b_items[0]) if b_items else b_id }}
+                                {%- endif -%}
+                            </td>
+                            <td class="reorder-cell">
+                                {%- if a_id -%}
+                                    {%- set a_items = after_value | selectattr('_id', 'equalto', a_id) | list -%}
+                                    {{ _item_label(a_items[0]) if a_items else a_id }}
+                                {%- endif -%}
+                            </td>
+                        </tr>
                     {% endfor %}
-                </div>
-                <div class="reorder-row">
-                    <span class="reorder-label">After:</span>
-                    {% for item_id in after_common %}
-                        {% set items = after_value | selectattr('_id', 'equalto', item_id) | list %}
-                        {% if items %}<span class="reorder-item">{{ _item_label(items[0]) }}</span>{% if not loop.last %} <span class="reorder-arrow">→</span> {% endif %}{% endif %}
-                    {% endfor %}
-                </div>
-            </div>
+                </tbody>
+            </table>
         </div>
+    {% endif %}
+
+    {% else %}
+    {# ===== Label-based fallback (IDs were regenerated, match by natural key) ===== #}
+
+    {# --- ADDED by label --- #}
+    {% set ns = namespace(count=0) %}
+    {% for ai in after_value %}
+        {% if ai is mapping %}
+            {% set ai_lbl = _label_for(ai) %}
+            {% set ns2 = namespace(found=false) %}
+            {% for bi in before_value %}
+                {% if bi is mapping and _label_for(bi) == ai_lbl %}{% set ns2.found = true %}{% endif %}
+            {% endfor %}
+            {% if not ns2.found %}
+                {% if ns.count == 0 %}<div class="array-section array-items-added"><div class="array-section-header">Added:</div>{% endif %}
+                {% set ns.count = ns.count + 1 %}
+                <div class="array-item-added">
+                    <div class="array-item-header">+ {{ ai_lbl }}</div>
+                    <div class="array-item-body">{{ _item_fields(ai) }}</div>
+                </div>
+            {% endif %}
+        {% endif %}
+    {% endfor %}
+    {% if ns.count > 0 %}</div>{% endif %}
+
+    {# --- REMOVED by label --- #}
+    {% set ns = namespace(count=0) %}
+    {% for bi in before_value %}
+        {% if bi is mapping %}
+            {% set bi_lbl = _label_for(bi) %}
+            {% set ns2 = namespace(found=false) %}
+            {% for ai in after_value %}
+                {% if ai is mapping and _label_for(ai) == bi_lbl %}{% set ns2.found = true %}{% endif %}
+            {% endfor %}
+            {% if not ns2.found %}
+                {% if ns.count == 0 %}<div class="array-section array-items-removed"><div class="array-section-header">Removed:</div>{% endif %}
+                {% set ns.count = ns.count + 1 %}
+                <div class="array-item-removed">
+                    <div class="array-item-header">- {{ bi_lbl }}</div>
+                    <div class="array-item-body">{{ _item_fields(bi) }}</div>
+                </div>
+            {% endif %}
+        {% endif %}
+    {% endfor %}
+    {% if ns.count > 0 %}</div>{% endif %}
+
+    {# --- MODIFIED by label (in both, content differs) --- #}
+    {% set ns = namespace(count=0) %}
+    {% for bi in before_value %}
+        {% if bi is mapping %}
+            {% set bi_lbl = _label_for(bi) %}
+            {% for ai in after_value %}
+                {% if ai is mapping and _label_for(ai) == bi_lbl %}
+                    {% set all_keys = (bi.keys()|list + ai.keys()|list)|unique|list %}
+                    {% set ns2 = namespace(changed=false) %}
+                    {% for k in all_keys %}
+                        {% if k != '_id' and bi.get(k) != ai.get(k) %}{% set ns2.changed = true %}{% endif %}
+                    {% endfor %}
+                    {% if ns2.changed %}
+                        {% if ns.count == 0 %}<div class="array-section array-items-modified"><div class="array-section-header">Modified:</div>{% endif %}
+                        {% set ns.count = ns.count + 1 %}
+                        <div class="array-item-changed">
+                            <div class="array-item-header">~ {{ bi_lbl }}</div>
+                            <div class="array-item-body">{{ _item_diff(bi, ai) }}</div>
+                        </div>
+                    {% endif %}
+                {% endif %}
+            {% endfor %}
+        {% endif %}
+    {% endfor %}
+    {% if ns.count > 0 %}</div>{% endif %}
+
+    {# --- REORDERED by label --- #}
+    {% set before_common = [] %}
+    {% set after_common  = [] %}
+    {% for bi in before_value %}
+        {% if bi is mapping %}
+            {% set bi_lbl = _label_for(bi) %}
+            {% set ns2 = namespace(found=false) %}
+            {% for ai in after_value %}
+                {% if ai is mapping and _label_for(ai) == bi_lbl %}{% set ns2.found = true %}{% endif %}
+            {% endfor %}
+            {% if ns2.found %}{% set _ = before_common.append(bi_lbl) %}{% endif %}
+        {% endif %}
+    {% endfor %}
+    {% for ai in after_value %}
+        {% if ai is mapping %}
+            {% set ai_lbl = _label_for(ai) %}
+            {% set ns2 = namespace(found=false) %}
+            {% for bi in before_value %}
+                {% if bi is mapping and _label_for(bi) == ai_lbl %}{% set ns2.found = true %}{% endif %}
+            {% endfor %}
+            {% if ns2.found %}{% set _ = after_common.append(ai_lbl) %}{% endif %}
+        {% endif %}
+    {% endfor %}
+    {% if before_common != after_common and before_common|length > 1 %}
+        <div class="array-section array-items-reordered">
+            <div class="array-section-header">Reordered:</div>
+            <table class="reorder-table">
+                <thead>
+                    <tr>
+                        <th class="reorder-pos-header">#</th>
+                        <th>Before</th>
+                        <th>After</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% set max_len = [before_common|length, after_common|length]|max %}
+                    {% for i in range(max_len) %}
+                        {% set b_lbl = before_common[i] if i < before_common|length else '' %}
+                        {% set a_lbl = after_common[i] if i < after_common|length else '' %}
+                        {% set row_moved = (b_lbl != a_lbl) %}
+                        <tr class="{{ 'reorder-row-moved' if row_moved else 'reorder-row-same' }}">
+                            <td class="reorder-pos-num">{{ i + 1 }}</td>
+                            <td class="reorder-cell">{{ b_lbl }}</td>
+                            <td class="reorder-cell">{{ a_lbl }}</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
+
     {% endif %}
 {% endmacro %}
 

--- a/templates/nation_owner_edit.html
+++ b/templates/nation_owner_edit.html
@@ -686,6 +686,7 @@
                 <div class="districts-grid">
                     {% for district_field in form.districts %}
                         <div class="district-slot">
+                            {{ district_field.item_id() }}
                             <label for="{{ district_field.id }}">Slot {{ loop.index }}</label></br></br>
                             {{ district_field.form.type.label }}: {{ district_field.form.type(class="form-control") }}
                             {{ district_field.form.node.label }}: {{ district_field.form.node(class="form-control") }}
@@ -708,8 +709,9 @@
                     <div class="districts-grid">
                         {% for city_field in form.cities %}
                             <div class="district-slot">
+                                {{ city_field.item_id() }}
                                 <label for="{{ city_field.id }}">Slot {{ loop.index }}</label></br></br>
-                                {{ city_field.form.name.label }}: {{ city_field.form.name(class="form-control") }}</br>                   
+                                {{ city_field.form.name.label }}: {{ city_field.form.name(class="form-control") }}</br>
                                 {{ city_field.form.type.label }}: {{ city_field.form.type(class="form-control") }}
                                 {{ city_field.form.node.label }}: {{ city_field.form.node(class="form-control") }}
                                 {{ city_field.form.wall.label }}: {{ city_field.form.wall(class="form-control") }}
@@ -851,7 +853,7 @@
                         <tbody id="progress_quests-tbody" class="sortable-tbody">
                             {% for quest_field in form.progress_quests %}
                                 <tr class="sortable-row">
-                                    <td>{{ quest_field.quest_name(class="form-control") }}</td>
+                                    <td>{{ quest_field.item_id() }}{{ quest_field.quest_name(class="form-control") }}</td>
                                     <td>{{ quest_field.slot(class="form-control") }}</td>
                                     <td>{{ quest_field.bonus_progress_per_tick(class="form-control") }}</td>
                                     <td>{{ quest_field.current_progress(class="form-control") }}</td>
@@ -890,7 +892,7 @@
                     <tbody id="modifiers-tbody">
                         {% for modifier_field in form.modifiers %}
                             <tr>
-                                <td>{{ modifier_field.field(class="form-control") }}</td>
+                                <td>{{ modifier_field.item_id() }}{{ modifier_field.field(class="form-control") }}</td>
                                 <td>{{ modifier_field.value(class="form-control") }}</td>
                                 <td>{{ modifier_field.duration(class="form-control") }}</td>
                                 <td>{{ modifier_field.source(class="form-control") }}</td>

--- a/tests/test_change_helpers.py
+++ b/tests/test_change_helpers.py
@@ -197,13 +197,14 @@ class TestKeepOnlyDifferences:
         new_before, new_after = ch.keep_only_differences(before, after, "Add")
         assert new_after == {"name": "NewNation", "gold": 0}
 
-    def test_empty_after_dict_with_non_empty_before_preserves_both(self):
-        # When after_data is empty and before isn't, the whole before is returned
-        # (signals intent to clear the field)
+    def test_empty_after_dict_with_non_empty_before_returns_empty(self):
+        # When after_data is empty it means the form submitted nothing for this
+        # sub-dict (e.g. a NavalUnitAssignmentDict with no registered fields).
+        # There are no tracked keys to diff, so both sides return empty — no change.
         before = {"x": 1}
         after  = {}
         new_before, new_after = ch.keep_only_differences_dict(before, after)
-        assert new_before == {"x": 1}
+        assert new_before == {}
         assert new_after  == {}
 
 
@@ -1030,6 +1031,54 @@ class TestCheckNoOtherChangesIdBased:
         a = {"mods": [{"v": 5}]}
         c = {"mods": [{"v": 1}]}   # current matches before → OK
         assert ch.check_no_other_changes(b, a, c) is True
+
+    def test_reorder_with_server_calculated_fields_in_current_returns_true(self):
+        """Approval must succeed even when the live DB document has server-calculated
+        fields that were stripped from the stored before/after items by
+        keep_only_differences_list.
+
+        Scenario
+        --------
+        Two progress_quest items exist.  The user reorders them (A, B → B, A).
+        The stored change holds before/after items with only the fields the form
+        submitted — no ``total_progress_per_tick`` (a server-calculated field).
+        The live DB document includes ``total_progress_per_tick: 5`` on every item.
+
+        check_no_other_changes must return True (no external conflict exists —
+        the only difference between stored before and live DB is the extra
+        calculated field, which the form never tracked).
+        """
+        id_a = "aaaaaaaaaaaaaaaaaaaaaaaa"
+        id_b = "bbbbbbbbbbbbbbbbbbbbbbbb"
+
+        # Stored before: no calculated fields (stripped by keep_only_differences_list)
+        before = {"progress_quests": [
+            {"_id": id_a, "quest_name": "Alpha", "slot": 1, "current_progress": 0,
+             "required_progress": 10, "bonus_progress_per_tick": 1, "link": ""},
+            {"_id": id_b, "quest_name": "Beta",  "slot": 2, "current_progress": 3,
+             "required_progress": 10, "bonus_progress_per_tick": 2, "link": ""},
+        ]}
+
+        # Stored after: same items reordered (B now first), still no calculated fields
+        after = {"progress_quests": [
+            {"_id": id_b, "quest_name": "Beta",  "slot": 1, "current_progress": 3,
+             "required_progress": 10, "bonus_progress_per_tick": 2, "link": ""},
+            {"_id": id_a, "quest_name": "Alpha", "slot": 2, "current_progress": 0,
+             "required_progress": 10, "bonus_progress_per_tick": 1, "link": ""},
+        ]}
+
+        # Live DB: same content as before-order, but WITH server-calculated field.
+        # This extra field must NOT cause a false conflict.
+        current = {"progress_quests": [
+            {"_id": id_a, "quest_name": "Alpha", "slot": 1, "current_progress": 0,
+             "required_progress": 10, "bonus_progress_per_tick": 1, "link": "",
+             "total_progress_per_tick": 5},   # server-calculated — not in before/after
+            {"_id": id_b, "quest_name": "Beta",  "slot": 2, "current_progress": 3,
+             "required_progress": 10, "bonus_progress_per_tick": 2, "link": "",
+             "total_progress_per_tick": 5},   # server-calculated — not in before/after
+        ]}
+
+        assert ch.check_no_other_changes(before, after, current) is True
 
 
 class TestIdsAutoAssignedOnRequest:


### PR DESCRIPTION
Four bugs fixed in the change request/approval pipeline:

1. WTForms _id field invisible to template renderer WTForms FormMeta silently drops field names starting with '_', so `_id = HiddenField` was never registered. Renamed to `item_id` in all five sub-forms (ModifierForm, ProgressQuestForm, DistrictDict, CityDict, ExternalModifierForm), updated templates to render item_id(), and added _normalize_item_ids() in change_helpers to remap item_id → _id on form submission.

2. Server-calculated fields shown as 'value → None' in change display keep_only_differences_list was passing DB before-items verbatim; computed fields absent from the form POST appeared as changes. Fixed by filtering each before-item to only the keys present in the matching after-item.

3. Naval units array falsely wiped (all values shown as 0 → None) keep_only_differences_dict had an early-return that treated an empty after_data dict as 'intentional clear'. Removed the early-return; empty form data now produces ({}, {}) — no tracked change.

4. Change approval failed with 'target has changed' after fix 2 Fix 2 stripped calculated fields from stored before/after items. During approval check_no_other_changes compared live DB items (which include calculated fields) to stored items (which don't), causing deep_compare to find a false key-count mismatch. Fixed by projecting the live DB item onto the tracked key set of the stored before/after item before comparing. Added regression test confirming the fix.

Also:
- Replaced arrow-separated reorder display with a numbered two-column table (unchanged rows muted, moved rows highlighted in amber)
- Added CSS classes for array diff sections
- Updated stale test for keep_only_differences_dict empty-after behaviour